### PR TITLE
feat(§9): Add Multi-Session Parallel Work policy (v1.4.0)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -185,6 +185,11 @@ All three sub-teams (Monolith, Syndicate, Arcade) work in parallel across every 
 
 **Early Phase Advance gate:** A team that completes all Phase N tickets must wait for Commander ท่านผู้บัญชาการ's explicit authorization before advancing to Phase N+1. AM cannot grant this. **COO Sync Gate:** Async phase advance requires explicit COO opt-in. Default is synchronous (all teams finish → Commander accepts → all advance). Provisional advances do not stack.
 
+### §9 — Multi-Session Parallel Work
+> Full standard in: `TeamDocument/1. Policies/09_Multi_Session_Parallel_Work.md`
+
+When Commander runs multiple CLI sessions simultaneously on different projects, each session must declare its project and tag all RoundTable entries with a project prefix. **Hard rule: one session per project — never two sessions on the same project.** Session numbers are first-come-first-served. OverseerReport entries use project-prefixed sections. Full rules in §9 policy file.
+
 ### Quality Standards
 
 **Testing:** Teams MUST write and run tests for every ticket they implement. Unit tests for all new functions/methods/endpoints. Integration tests for cross-module interactions. Verification Scholar signs off on test results before OverseerReport is filed.
@@ -219,8 +224,9 @@ All three sub-teams (Monolith, Syndicate, Arcade) work in parallel across every 
 | §6 | Debugging Protocol, Instrument-First Rule, INDEV Persistent Probes, Cross-Layer Trace, Rewrite Threshold, Gap Bug Detection | `TeamDocument/1. Policies/06_Debugging_Protocol.md` |
 | §7 | Parallel Execution, ZCB Guarantee, Ticket Ownership, Commander Sync Gate | `TeamDocument/1. Policies/07_Parallel_Execution.md` |
 | §8 | Skills (slash commands), Subagent standard, Trigger Conditions, Pre-Flight Declaration | `TeamDocument/1. Policies/08_Skills_and_Subagents.md` |
+| §9 | Multi-Session Parallel Work, one-session-per-project, project-prefixed logging | `TeamDocument/1. Policies/09_Multi_Session_Parallel_Work.md` |
 
-> **Loading rule:** Policy files are read on-demand. Teams do NOT need to read all 8 at session start — CLAUDE.md is sufficient for initialization. Read the specific policy when needed.
+> **Loading rule:** Policy files are read on-demand. Teams do NOT need to read all 9 at session start — CLAUDE.md is sufficient for initialization. Read the specific policy when needed.
 
 ---
 

--- a/.claude/TeamDocument/1. Policies/09_Multi_Session_Parallel_Work.md
+++ b/.claude/TeamDocument/1. Policies/09_Multi_Session_Parallel_Work.md
@@ -1,0 +1,126 @@
+# §9 — Multi-Session Parallel Work
+
+> **Policy reference file.** Loaded on-demand from `.claude/TeamDocument/1. Policies/`. Core rules live in CLAUDE.md.
+
+---
+
+## Purpose
+
+When Commander runs multiple Claude CLI sessions simultaneously (e.g., one session working on Project A, another on Project B), each session operates independently. This policy defines the rules that prevent shared-resource collisions while preserving a unified audit trail.
+
+**This policy extends §7 (Parallel Execution).** §7 covers parallel execution of *teams within a single session*. §9 covers parallel execution of *multiple CLI sessions across projects*.
+
+---
+
+## Hard Rules
+
+### Rule 1: One Session Per Project
+
+**Each CLI session owns exactly one project. Two sessions MUST NOT work on the same project simultaneously.**
+
+Rationale: Source code, test state, Development folders, plan files, and build artifacts are shared within a project. Concurrent writes from two sessions will cause silent merge conflicts, stale test results, and corrupted state.
+
+### Rule 2: Session Declaration
+
+At the start of each session, Commander declares which project that session owns. The session records this in its first RoundTable or Team Chat entry:
+
+```
+## Session [N] [ProjectName] — [Title]
+```
+
+The project prefix `[ProjectName]` appears in every session header for the duration of that CLI session. Example:
+
+```
+## Session 17 [SyncSpace] — Phase 2 Room CRUD
+## Session 18 [AeroMedica] — 3D Asset Pipeline Fix
+## Session 19 [SyncSpace] — Phase 2 Presence Protocol
+```
+
+### Rule 3: Session Numbering — First-Come-First-Served
+
+Session numbers are global (not per-project) and assigned by the order sessions write to the RoundTable file. If Session A and Session B both start:
+
+- Whichever session writes its entry first claims the next session number
+- The other session claims the following number
+- There are no reserved or pre-allocated session numbers
+
+### Rule 4: Shared RoundTable File
+
+All sessions write to the **same daily RoundTable Volume file**. The project prefix in the session header distinguishes entries. This preserves the chronological cross-project timeline.
+
+**Vol rotation:** Each session checks the current Vol file's line count before every write (standard §1 behavior). If a session detects the file has passed the 400-line soft limit (potentially due to another session's writes), it rotates to a new Vol immediately.
+
+### Rule 5: OverseerReport — Project-Prefixed Sections
+
+When multiple sessions file to the same daily OverseerReport, each entry includes a project header:
+
+```markdown
+## [ProjectName]
+
+### [TicketID] — [Title]
+...
+```
+
+This prevents interleaving of unrelated project reports in the shared file.
+
+---
+
+## Safe Resources (No Collision)
+
+These resources are inherently isolated across projects and require no special handling:
+
+| Resource | Why It's Safe |
+|----------|--------------|
+| **Source code** | Different `SOURCE_ROOT` per project (see `ProjectEnvironment.md`) |
+| **Development folders** | Each project has its own `Development/` tree |
+| **Plan files** | UUID-named, per-session |
+| **Team Chat logs** | Each team writes to its own subfolder (`TeamChat/1. Monolith/`, `2. Syndicate/`, etc.) |
+| **Phase Briefings** | Project-scoped, inside each project's Development folder |
+
+---
+
+## Collision-Prone Resources
+
+These require the rules above to remain safe:
+
+| Resource | Mitigation |
+|----------|-----------|
+| **RoundTable Vol file** | Project prefix on session headers (Rule 2 + Rule 4) |
+| **`_Index.md`** | Each session updates after its own Vol rotation — check before write |
+| **OverseerReport** | Project-prefixed sections (Rule 5) |
+| **Session numbering** | First-come-first-served (Rule 3) |
+| **`ProjectEnvironment.md`** | Low risk — only update if adding/removing a project. Check before write. |
+
+---
+
+## What Happens If Rules Are Violated
+
+| Violation | Consequence | Recovery |
+|-----------|-------------|----------|
+| Two sessions on same project | Silent merge conflicts, stale tests, corrupted state | Stop one session immediately. Audit changed files. |
+| Missing project prefix | RoundTable entries become unreadable — cannot tell which project a session belongs to | Retroactively add prefixes to session headers |
+| Both sessions rotate Vol simultaneously | Duplicate Vol files or skipped Vol numbers | AM reconciles `_Index.md` manually |
+
+---
+
+## Quick Reference
+
+```
+BEFORE STARTING A PARALLEL SESSION:
+1. Commander declares: "This session works on [ProjectName]"
+2. Session logs: ## Session [N] [ProjectName] — [Title]
+3. Verify no other session is working on the same project
+4. Check RoundTable Vol line count before first write
+
+DURING THE SESSION:
+- All session headers include [ProjectName]
+- Check Vol line count before every write (standard §1)
+- OverseerReport entries include project header
+
+ON SESSION END:
+- No special cleanup required — entries are already project-tagged
+```
+
+---
+
+*Added: 13-03-2026 — Originated from RoundTable Vol5 Session 16-17 discussion*

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Welcome to RoundTable Framework! Thank you for opening your first issue.
 
             A maintainer will review this shortly. While you wait:
@@ -27,7 +27,7 @@ jobs:
             - Browse [Discussions](https://github.com/VarakornUnicornTech/unicorn_roundtable_framework_repo/discussions) for common questions
 
             Thank you for helping improve RoundTable Framework!
-          pr-message: |
+          pr_message: |
             Welcome to RoundTable Framework! Thank you for your first pull request.
 
             A maintainer will review it shortly. Please make sure you've:

--- a/template-version.json
+++ b/template-version.json
@@ -1,13 +1,13 @@
 {
   "name": "roundtable-framework",
-  "version": "1.3.0",
-  "description": "RoundTable Framework for Claude Code — Multi-team AI governance template",
+  "version": "1.4.0",
+  "description": "RoundTable Framework for Claude Code \u00e2\u20ac\u201d Multi-team AI governance template",
   "author": "Unicorn",
   "license": "MIT",
   "released": "2026-03-13",
-  "notes": "v1.3.0 — BREAKING: Full restructure with path changes (policies/ → TeamDocument/1. Policies/, Team Roster → agents/, Team Chat → TeamDocument/2. TeamChat/). See MIGRATION.md. Full restructure: agents/ as sole identity source (Team Roster removed), TeamDocument/ consolidation, SESSION START RULE every session, AM Mode A/B + COO Vision Gate, Architecture Decision Rule, §8 Skills & Subagents policy, /template + consolidated skill set (14 skills).",
+  "notes": "v1.4.0 \u2014 Added \u00a79 Multi-Session Parallel Work policy. Enables safe concurrent CLI sessions across different projects with project-prefixed RoundTable logging, first-come-first-served session numbering, and one-session-per-project hard rule.",
   "file_hashes": {
-    ".claude/CLAUDE.md": "0940173a7d31a5b45e2e3d08c36cf5b374c466bbd5a122ae8cd74090c9f45290",
+    ".claude/CLAUDE.md": "0855ab496961b53f8f1ddfc25af3c3b71fe2ed2389ccc6cfc4944b90d20ce1ba",
     ".claude/TeamDocument/1. Policies/01_Logging_and_RoundTable.md": "68abd6c736508b857567680debdad35b7e78a762896007c727db630b76c73070",
     ".claude/TeamDocument/1. Policies/02_Ticket_and_Briefing.md": "d66db0f20635825259b5efa9ebc23a21b4f6829be22791f803aee550805fcfe2",
     ".claude/TeamDocument/1. Policies/03_TeamChat_and_Handover.md": "0a6aba4bb57267af1b656a868eaed8406de3972099302d7fb4ac7600a5531662",
@@ -34,6 +34,7 @@
     ".claude/agents/monolith.md": "a6f6b6036635425d4b1fc7ca3886f5d484c36d5042fceb578172f3f87ecf8020",
     ".claude/agents/syndicate.md": "426b6d9f6d99a21e4c48d62b8499e366211be9c37cc6db1a29b77ae675e246aa",
     ".claude/agents/arcade.md": "3b4b33abc7a075f83cc15329d2e9798fdf597a960c1e70bf93e286f966e55c42",
-    ".claude/agents/cipher.md": "a61fae8322d69c6ec9f86f8e650011f6396439608afed8711c68a8690db5879a"
+    ".claude/agents/cipher.md": "a61fae8322d69c6ec9f86f8e650011f6396439608afed8711c68a8690db5879a",
+    ".claude/TeamDocument/1. Policies/09_Multi_Session_Parallel_Work.md": "acb1f26aef01d0b45eecc8e8ca60c1001c31f8b3986ec41aa6c01319b593dbe0"
   }
 }


### PR DESCRIPTION
## Summary

- **New policy: §9 Multi-Session Parallel Work** — enables safe concurrent CLI sessions across different projects
- **Fix: welcome.yml workflow** — corrected kebab-case input names to snake_case for `actions/first-interaction@v3`
- **Version bump: v1.3.0 → v1.4.0**

### §9 Policy Highlights
- **One-session-per-project hard rule** — two sessions MUST NOT work on the same project simultaneously
- **Project-prefixed session headers** — format: `## Session [N] [ProjectName] — [Title]`
- **First-come-first-served session numbering** — global numbers, no reservations
- **Project-prefixed OverseerReport sections** — prevents interleaving across projects
- **Vol rotation awareness** — each session checks line count before every write

### Files Changed
| File | Change |
|------|--------|
| `.claude/TeamDocument/1. Policies/09_Multi_Session_Parallel_Work.md` | NEW — full §9 policy document |
| `.claude/CLAUDE.md` | Added §9 summary section + policy reference index entry |
| `template-version.json` | Version bump to v1.4.0, new file hashes |
| `.github/workflows/welcome.yml` | Fix: `repo-token` → `repo_token`, `issue-message` → `issue_message`, `pr-message` → `pr_message` |

### MIGRATION.md
No migration steps required. New policy file is additive — existing installations gain §9 by running `/template apply`.

## Test plan
- [x] Verify §9 policy file renders correctly in markdown
- [x] Verify CLAUDE.md §9 summary is consistent with full policy
- [x] Verify template-version.json has correct SHA-256 hash for new file
- [x] Verify welcome.yml uses correct snake_case input names for `actions/first-interaction@v3`
- [ ] CI workflow passes with corrected welcome.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)