### PR TITLE
docs: fix Manual Install guide, add VSCode Extension section, clarify setup terminology

### DIFF
--- a/.claude/skills/roundtable-setup/SKILL.md
+++ b/.claude/skills/roundtable-setup/SKILL.md
@@ -57,21 +57,21 @@ Ask each question one at a time using `AskUserQuestion`.
 - Options: `English` / `Mirror input language (bilingual — respond in whichever language the message was written in)`
 - Header: `Language`
 - Description for each:
-  - English — all responses in English regardless of input language
-  - Mirror input language (bilingual) — RoundTable mirrors the language of each individual message. If you write in English, the response is in English. If you write in another language, the response matches. Recommended for multilingual sessions.
-- Note: Most users will type their preferred language (e.g., "Thai", "Japanese", "Spanish") via the free-text input. The options above are common defaults.
+  - English — all responses in English regardless of what language you write in
+  - Mirror input language (bilingual) — RoundTable automatically matches the language of each message. Write in Thai → response in Thai. Write in English → response in English. Useful if you switch languages mid-session or share the session with others.
+- Note: Most users will type their preferred language name directly (e.g., "Thai", "Japanese", "Spanish") via the free-text input. The options above are common defaults.
 
 **From this point forward, present all remaining questions and text in the user's chosen language.**
 
 **Question (2/5):**
-> "(2/5) What position title should AM and the teams use when addressing you?"
+> "(2/5) What title should the AI team use when addressing you? (AM is the team lead AI who coordinates everything on your behalf.)"
 - Options: `Commander` / `Boss` / `Chief` / `Other — type your preferred title`
 - Header: `Callsign`
 - Description for each:
-  - Commander — formal military-style rank
-  - Boss — direct authority title
+  - Commander — formal authority title (the default; used throughout all team logs and reports)
+  - Boss — a direct, informal authority title
   - Chief — leadership-focused title
-  - Other — enter any custom title you prefer
+  - Other — type any custom title you prefer (e.g., "Captain", "Director", your own name)
 
 **Question (3/5):**
 > "(3/5) What is your name?"
@@ -94,6 +94,8 @@ Ask each question one at a time using `AskUserQuestion`.
 
 - If **Use defaults** → apply defaults (see table below), skip to Step 4 (Confirm Before Saving).
 - If **Configure** → proceed to Step 2 (Advanced Setup).
+
+> **When "Use defaults" is selected:** All 4 teams are active (Overseer, Monolith, Syndicate, Arcade). The team lead AI (AM) manages them on your behalf — you give one instruction and receive one consolidated report. Responses are balanced in length. You approve major decisions; minor tasks run independently.
 
 **Defaults when skipped:**
 
@@ -137,15 +139,15 @@ Ask each question one at a time using `AskUserQuestion`. No progress counter for
 > "Which teams should be active by default?" (multiSelect: true)
 - Options: `Overseer (always on)` / `Monolith` / `Syndicate` / `Arcade`
 - Header: `Active teams`
-- Note: Cipher is always available on-demand — not listed here.
+- Note: Cipher (the forensic/hardware diagnostic specialist) is always available on-demand from Commander — not listed here because Cipher operates outside the normal team hierarchy.
 
 **Orchestration Mode:**
 > "Default orchestration mode?"
 - Options: `Mode A — AM Direct (one prompt in, consolidated report out)` / `Mode B — Separate sessions (you manage each team directly)`
 - Header: `Orchestration`
 - Description for each:
-  - Mode A — You give AM one instruction. AM spawns all sub-teams, collects results, and presents a single consolidated report. Best for efficiency.
-  - Mode B — You open a separate Claude session per team and interact with each directly. Best for hands-on control and real-time course correction.
+  - Mode A — You give AM (the team lead AI) one instruction. AM assigns tasks to all sub-teams, collects their results, and presents a single consolidated report. Best for efficiency — you only talk to AM.
+  - Mode B — You open a separate Claude session per team and interact with each team directly. Best for hands-on control and real-time course correction.
 
 **Phase Acceptance Gate:**
 > "Commander Phase Acceptance Gate — do you want to personally test and accept each phase before teams advance?"
@@ -194,8 +196,8 @@ Ask each question one at a time using `AskUserQuestion`. No progress counter for
 - Options: `Professional — clean and formal, no decorations` / `Expressive — team members show personality with emojis and kaomoji`
 - Header: `Tone`
 - Description for each:
-  - Professional — straight to the point. No emojis, no kaomoji. Clean, formal output.
-  - Expressive — team members can use emojis and kaomoji to convey feelings and reactions. Adds personality to reports, logs, and responses.
+  - Professional — straight to the point. No emojis, no kaomoji. Clean, formal output only.
+  - Expressive — team members can use emojis 🎉 and kaomoji (e.g., ヽ(・∀・)ﾉ) to convey feelings and reactions. Adds personality to reports, logs, and responses.
 
 Save answers to profile section: `## Working Style`
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [Why UniOps Quantum Cycle?](#-why-uniops-quantum-cycle)
 - [Quick Start](#-quick-start)
 - [Three Ways to Use](#-three-ways-to-use-uniops-quantum-cycle)
+- [VSCode Extension](#-vscode-extension-uniopsqc-hub)
 - [Teams](#-teams)
 - [Skills](#-skills)
 - [Rules & Hooks](#-rules-path-scoped)
@@ -90,28 +91,38 @@ Install UniOps Quantum Cycle from https://github.com/VarakornUnicornTech/UniOpsQ
 
 ### Manual Install
 
+> [!NOTE]
+> Replace `C:/Projects/my-project` in the commands below with the **actual path to your project folder** — the folder where you want to install UniOps Quantum Cycle.
+
 **Bash / Git Bash / macOS / Linux:**
 ```bash
 git clone https://github.com/VarakornUnicornTech/UniOpsQC.git .claude-template
-cp -r .claude-template/.claude/ your-project/.claude/
-cp .claude-template/plugin.json your-project/plugin.json
-cp .claude-template/.mcp.json your-project/.mcp.json
-cp -r .claude-template/hooks/ your-project/hooks/
+cp -r .claude-template/.claude/ C:/Projects/my-project/.claude/
+cp .claude-template/template-version.json C:/Projects/my-project/template-version.json
+cp .claude-template/plugin.json C:/Projects/my-project/plugin.json
+cp .claude-template/.mcp.json C:/Projects/my-project/.mcp.json
+cp -r .claude-template/hooks/ C:/Projects/my-project/hooks/
 rm -rf .claude-template
 ```
 
 **PowerShell (Windows):**
 ```powershell
 git clone https://github.com/VarakornUnicornTech/UniOpsQC.git .claude-template
-Copy-Item -Recurse .claude-template\.claude\ your-project\.claude\
-Copy-Item .claude-template\plugin.json your-project\plugin.json
-Copy-Item .claude-template\.mcp.json your-project\.mcp.json
-Copy-Item -Recurse .claude-template\hooks\ your-project\hooks\
+Copy-Item -Recurse .claude-template\.claude\ C:\Projects\my-project\.claude\
+Copy-Item .claude-template\template-version.json C:\Projects\my-project\template-version.json
+Copy-Item .claude-template\plugin.json C:\Projects\my-project\plugin.json
+Copy-Item .claude-template\.mcp.json C:\Projects\my-project\.mcp.json
+Copy-Item -Recurse .claude-template\hooks\ C:\Projects\my-project\hooks\
 Remove-Item -Recurse -Force .claude-template
 ```
 
 > [!TIP]
-> After cloning, edit `.claude/ProjectEnvironment.md` with your project name and paths before starting Claude Code for the first time.
+> After installing, edit `.claude/ProjectEnvironment.md` with your project name and paths before starting Claude Code for the first time.
+
+> [!NOTE]
+> **Windows — Hook scripts require `jq`:** Install via [winget](https://winget.run/pkg/jqlang/jq) (`winget install jqlang.jq`) or [Chocolatey](https://chocolatey.org/) (`choco install jq`), then restart your terminal. Without `jq`, hook scripts will not function.
+>
+> **Playwright MCP (optional):** Required only if you want browser automation for UX smoke tests. Install [Node.js](https://nodejs.org/) and run `npx playwright install` inside your project.
 
 ---
 
@@ -142,6 +153,48 @@ Remove-Item -Recurse -Force .claude-template
   </td>
 </tr>
 </table>
+
+---
+
+## 🖥️ VSCode Extension — UniOpsQC Hub
+
+**UniOpsQC Hub** is a companion VSCode extension that gives you a visual dashboard alongside Claude Code.
+
+**Install:** Search for `UniOpsQC Hub` or `RoundTable Hub` in the VSCode Marketplace, or install extension ID `unicorntech.roundhub`.
+
+### What It Does
+
+The extension does **not** run Claude Code — it is a **command launcher and log viewer** that works alongside the CLI.
+
+| Button | What It Does |
+|--------|-------------|
+| **Quick Actions** | Copies a `/command` to your clipboard — paste it into Claude Code to run |
+| **SESSION LOGS** | Displays your RoundTable session log files for the active project |
+| **FRAMEWORK STATUS** | Shows the installed framework version (requires a `.git` repository) |
+| **Push to Hub** | Syncs your RoundTable logs to a cloud dashboard (subscription feature — not yet available) |
+| **Update Preview** | Copies the `/template preview` command to your clipboard — paste into Claude Code to run |
+| **Refresh** | Reloads the extension panel to reflect the latest file changes |
+
+### Two Versions — What Each Shows
+
+The extension panel displays two version numbers:
+
+| Version | What It Is | Where It Comes From |
+|---------|-----------|---------------------|
+| **Framework version** (e.g., `v2.0.0`) | The UniOpsQC template version | Read from your project's `.git` tags or `template-version.json` |
+| **Extension version** (e.g., `v1.6.0`) | The VSCode extension itself | The extension's own release version in the Marketplace |
+
+> [!TIP]
+> The framework and extension are versioned independently. A newer extension does not mean a newer framework, and vice versa.
+
+### Centralized vs. Decentralized Projects
+
+When you add a project in the extension, you will be asked for a **Project Name** and **Project Root**. UniOpsQC supports two project modes (set in `.claude/ProjectEnvironment.md`):
+
+| Mode | When to Use | Root Path Points To |
+|------|-------------|---------------------|
+| **Centralized** | Greenfield or solo projects | The folder containing both `.claude/` and your source code |
+| **Decentralized** | Pre-existing codebases | The planning hub folder (containing `.claude/`), which is separate from the source code |
 
 ---
 


### PR DESCRIPTION
## Summary

- **Manual Install guide fixed**: replaced ambiguous `your-project` placeholder with a real concrete path example (`C:/Projects/my-project`), added the missing `template-version.json` copy step, and added Windows notes for `jq` (required for hooks) and Node.js (Playwright MCP)
- **VSCode Extension section added**: new section covering how to install the UniOpsQC Hub extension, what each button does, the two-version system (framework vs. extension), and the Centralized vs. Decentralized project mode explainer
- **roundtable-setup SKILL.md clarified**: explained who "AM" is in Q2, improved Callsign option descriptions, replaced "spawns" jargon in Mode A with plain language, added a kaomoji example for the Expressive tone option, explained Cipher's role, expanded the Mirror input language description, and added an upfront summary of what "Use defaults" actually enables

## Motivation

These fixes come from **real first-time-user testing** (fresh Windows install, no prior knowledge of the framework). Every gap documented here was encountered during actual setup — not theoretical review.

Key pain points discovered:
- `your-project` placeholder in Manual Install caused confusion — it's not obvious this should be replaced
- `template-version.json` was missing from the install steps, causing the VSCode Extension to show an error and the Health Check to report 94% (16/17 files)
- No VSCode Extension documentation anywhere in README — users who find the Marketplace listing have no guide to understand what buttons do or how the extension relates to the CLI
- `AM`, `spawns`, `kaomoji`, and `Cipher` in roundtable-setup onboarding were unfamiliar terms to first-time users, causing confusion during setup

## Test plan

- [ ] Manual Install steps verified on Windows (Git Bash + PowerShell) — all 6 files copy correctly
- [ ] `template-version.json` confirmed present after install — Extension Health Check reaches 100%
- [ ] VSCode Extension section reviewed against actual Extension UI (v1.6.0)
- [ ] roundtable-setup SKILL.md changes verified — onboarding flow still executes correctly, no structural changes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Contributed by: **oiovibecode** — first-time user testing on Windows